### PR TITLE
Move prezto as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "prezto"]
+	path = prezto
+	url = git@github.com:menor/prezto.git

--- a/README.md
+++ b/README.md
@@ -2,3 +2,14 @@ My configuration files, they use [this script](http://blog.smalleycreative.com/t
 To track new files:
 - Add them to the files variable in makesymlinks.sh
 - Run the script (this script creates symlinks to the dotfiles in the home directory)
+
+
+
+Prezto is included as a submodule, to we need to create symlinks from that folder to the main zsh dir to do that run this:
+
+```
+setopt EXTENDED_GLOB
+for rcfile in "${ZDOTDIR:-$HOME}"/dotfiles/prezto/runcoms/^README.md(.N); do
+ln -s "$rcfile" "${ZDOTDIR:-$HOME}/.${rcfile:t}"
+done
+```

--- a/vimrc
+++ b/vimrc
@@ -42,6 +42,7 @@ set fileencoding=utf-8
 " Don't unload buffers when they are abandoned, instead stay in the background
 set hidden
 
+
 " Configure indentation
 set expandtab
 set shiftwidth=2


### PR DESCRIPTION
Had to remove:
- Remove old symlinks
- Update the submodules run this (from inside the prezto folder/repo)
```
git submodule update --init --recursive
```
- Change dirs inside `zshrc` and `initzsh` to point to the new prezto location (inside the dotfiles repo)

check this:
-  [Adding prezto as a submodule to dotfiles](https://hxmd.herokuapp.com/blog/2013/05/12/adding-prezto-as-a-submodule-to-dotfiles/)
- [Better zsh with prezto](https://wikimatze.de/better-zsh-with-prezto/)
