### PR TITLE
Remove reference to bash in tmux.conf

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -28,7 +28,7 @@ set -g status-right ''
 
 # Copy-paste integration
 # https://evertpot.com/osx-tmux-vim-copy-paste-clipboard/
-set-option -g default-command "reattach-to-user-namespace -l bash"
+set-option -g default-command "reattach-to-user-namespace -l zsh"
 
 # Use vim keybindings in copy mode
 setw -g mode-keys vi


### PR DESCRIPTION
This was making zsh not run inside tmux